### PR TITLE
LLAMA_CUBLAS=1 typo fix in autogguf.sh

### DIFF
--- a/scripts/autogguf.sh
+++ b/scripts/autogguf.sh
@@ -53,7 +53,7 @@ if [ ! -d "llama.cpp" ]; then
         echo "nvcc could not be found, building llama without LLAMA_CUBLAS"
         make clean && make
     else
-        make clean && LLAMA_CUBLAD=1 make
+        make clean && LLAMA_CUBLAS=1 make
     fi
     cd ..
 else


### PR DESCRIPTION
I miskeyed when making the conditional build, and typed LLAMA_CUBLAD instead of LLAMA_CUBLAS